### PR TITLE
Implemented synchronization selection

### DIFF
--- a/analysis/src/WZsynchro.cc
+++ b/analysis/src/WZsynchro.cc
@@ -569,7 +569,7 @@ WZsynchro::WZ3lSelection() {
   int munumber = 0;
   if(std::abs(l3[0]->pdgId())==13 ) munumber++;
   if(std::abs(l3[1]->pdgId())==13 ) munumber++;
-  if(std::abs(l3[2]->pdgId())==13 ) munumber++;  
+  if(std::abs(l3[2]->pdgId())==13 ) munumber++;
   if (_lepflav=="eee" && munumber!=0) return;
   if (_lepflav=="eem" && munumber!=1) return;
   if (_lepflav=="mme" && munumber!=2) return;


### PR DESCRIPTION
Now agreement with IFCA and other groups is of the order of 1% or better with the latest ntuples produced by Kike.

However, with our current samples (miniAOD v1) we will not have a perfect synchronization since the meaning of some branches has been changed in Kike's version of the Heppy tree producer. Namely LepGood_tightID currently corresponds to an MVA ID for electrons, while for the current ongoing Kike's  production of MiniAODv2 it represents the cut based ID used for the WZ cross section analysis
